### PR TITLE
Add page break documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -349,8 +349,11 @@ With obsidian, you just simply call all the notes into one
 Line breaks is a widely used tool, avaiable in everything from LaTex to Microsoft Word. It's especially useful if you want a seperate front page, or just dont like how a paragraph is split up it between two pages.
 
 To make a line break in obsidian, all you have to do is paste this HTML:
+
 `<div style="page-break-after: always;"></div>`
-It is important to note that you should always have a linebreak before and after this HTML tag, to make sure it works properly. Another note is that it's going to appear invisible in live-editor mode, unless you move your cursor to it with your arrow keys.
+
+It is __important to note__ that you should always have a linebreak before and after this HTML tag, to make sure it works properly. 
+Another note is that it's going to appear invisible in live-editor mode, unless you move your cursor to it with your arrow keys.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -344,6 +344,13 @@ With obsidian, you just simply call all the notes into one
 
 (TO_BE_ADDED)
 
+#### Line-breaks
+Line breaks is a widely used tool, avaiable in everything from LaTex to Microsoft Word. It's especially useful if you want a seperate front page, or just dont like how a paragraph is split up it between two pages.
+
+To make a line break in obsidian, all you have to do is paste this HTML:
+`<div style="page-break-after: always;"></div>`
+It is important to note that you should always have a linebreak before and after this HTML tag, to make sure it works properly. Another note is that it's going to appear invisible in live-editor mode, unless you move your cursor to it with your arrow keys.
+
 ---
 
 ## Contributing

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ To see this workflow in action, watch this [video](https://youtu.be/ZKQEgf2ktWE)
     -   [Other](#other)
         -   [Combine notes](#combine-notes)
         -   [Improving Math writing](#improving-math-writing)
+        -   [Line breaks](#line-breaks)
 -   [Contributing](#contributing)
 -   [Reference](#reference)
 
@@ -344,7 +345,7 @@ With obsidian, you just simply call all the notes into one
 
 (TO_BE_ADDED)
 
-#### Line-breaks
+#### Line breaks
 Line breaks is a widely used tool, avaiable in everything from LaTex to Microsoft Word. It's especially useful if you want a seperate front page, or just dont like how a paragraph is split up it between two pages.
 
 To make a line break in obsidian, all you have to do is paste this HTML:

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ To see this workflow in action, watch this [video](https://youtu.be/ZKQEgf2ktWE)
     -   [Other](#other)
         -   [Combine notes](#combine-notes)
         -   [Improving Math writing](#improving-math-writing)
-        -   [Line breaks](#line-breaks)
+        -   [Page breaks](#page-breaks)
 -   [Contributing](#contributing)
 -   [Reference](#reference)
 
@@ -345,14 +345,14 @@ With obsidian, you just simply call all the notes into one
 
 (TO_BE_ADDED)
 
-#### Line breaks
-Line breaks is a widely used tool, avaiable in everything from LaTex to Microsoft Word. It's especially useful if you want a seperate front page, or just dont like how a paragraph is split up it between two pages.
+#### Page breaks
+Page breaks is a widely used tool, avaiable in everything from LaTex to Microsoft Word. It's especially useful if you want a seperate front page, or just dont like how a paragraph is split up it between two pages.
 
-To make a line break in obsidian, all you have to do is paste this HTML:
+To make a page break in obsidian, all you have to do is paste this HTML:
 
 `<div style="page-break-after: always;"></div>`
 
-It is __important to note__ that you should always have a linebreak before and after this HTML tag, to make sure it works properly. 
+It is __important to note__ that you should always have a line break before and after this HTML tag, to make sure it works properly. 
 Another note is that it's going to appear invisible in live-editor mode, unless you move your cursor to it with your arrow keys.
 
 ---


### PR DESCRIPTION
Adds documentation for page breaks in Obsidian. I often use them to have a seperate page for my front page, abstract, summary or reference list.